### PR TITLE
Add student registration endpoints and student persistence

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -127,6 +127,56 @@ def save_persistence():
 # Load persistence at startup
 load_persistence()
 
+# --- Students persistence and registry ---
+STUDENTS_FILE = current_dir / "students.csv"
+
+class Student(
+    # lightweight dict-like model for older Python versions without pydantic
+):
+    def __init__(self, student_id: str, name: str, email: str):
+        self.student_id = student_id
+        self.name = name
+        self.email = email
+
+    def dict(self):
+        return {"student_id": self.student_id, "name": self.name, "email": self.email}
+
+
+# In-memory students registry (student_id -> Student)
+students = {}
+STUDENT_CAPACITY = 100
+
+
+def load_students():
+    """Load student registry from STUDENTS_FILE (CSV: student_id,name,email)"""
+    if not STUDENTS_FILE.exists():
+        return
+    try:
+        with STUDENTS_FILE.open("r", newline="") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if len(row) < 3:
+                    continue
+                sid, name, email = row[0], row[1], row[2]
+                students[sid] = Student(sid, name, email)
+    except Exception as e:
+        print(f"Failed to load students from {STUDENTS_FILE}: {e}")
+
+
+def save_students():
+    """Save student registry to STUDENTS_FILE (CSV: student_id,name,email)"""
+    try:
+        with STUDENTS_FILE.open("w", newline="") as f:
+            writer = csv.writer(f)
+            for sid, student in students.items():
+                writer.writerow([student.student_id, student.name, student.email])
+    except Exception as e:
+        raise RuntimeError(f"Failed to save students: {e}")
+
+
+# Load persistence at startup
+load_students()
+
 
 @app.get("/activities")
 def get_activities():
@@ -149,6 +199,10 @@ def signup_for_activity(activity_name: str, email: str):
             status_code=400,
             detail="Student is already signed up"
         )
+
+    # Check activity capacity
+    if len(activity["participants"]) >= activity.get("max_participants", 0):
+        raise HTTPException(status_code=400, detail="Activity is full")
 
     # Add student
     activity["participants"].append(email)
@@ -189,3 +243,50 @@ def unregister_from_activity(activity_name: str, email: str):
         raise HTTPException(status_code=500, detail=str(e))
 
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+# --- Student registration endpoints ---
+@app.post("/students")
+def register_student(student_id: str, name: str, email: str):
+    """Register a new student. Enforces unique student_id and capacity limit."""
+    # Capacity check
+    if len(students) >= STUDENT_CAPACITY:
+        raise HTTPException(status_code=400, detail="Student registry is full")
+
+    # Unique ID check
+    if student_id in students:
+        raise HTTPException(status_code=400, detail="Student ID already registered")
+
+    # Prevent duplicate emails (optional safety)
+    if any(s.email == email for s in students.values()):
+        raise HTTPException(status_code=400, detail="Email already registered")
+
+    students[student_id] = Student(student_id, name, email)
+    try:
+        save_students()
+    except RuntimeError as e:
+        # Rollback
+        del students[student_id]
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"message": f"Registered student {student_id}"}
+
+
+@app.get("/students/{student_id}")
+def get_student(student_id: str):
+    if student_id not in students:
+        raise HTTPException(status_code=404, detail="Student not found")
+    s = students[student_id]
+    return {"student_id": s.student_id, "name": s.name, "email": s.email}
+
+
+@app.get("/students")
+def list_students():
+    """Return roster sorted alphabetically by name"""
+    roster = sorted(list(students.values()), key=lambda s: s.name)
+    return [{"student_id": s.student_id, "name": s.name, "email": s.email} for s in roster]
+
+
+@app.get("/students/available_seats")
+def available_seats():
+    return {"available_seats": STUDENT_CAPACITY - len(students)}


### PR DESCRIPTION
This PR adds a basic student registry with persistence and new endpoints:

- POST /students : register a student with `student_id`, `name`, `email` (enforces unique ID and capacity limit = 100)
- GET /students : list students (sorted by name)
- GET /students/{student_id} : get a student record
- GET /students/available_seats : remaining capacity

Students are persisted to `students.csv` next to `results.txt`. Existing activity signup logic remains unchanged; activity signup now checks activity capacity before adding participants.